### PR TITLE
Add Table of Contents to README for Enhanced Navigation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,24 @@
+# Table of Contents
+1. [Project Overview](#mlops-for-document-classification-models)
+2. [Team Members](#team-members)
+3. [Data Preparation](#data-preparation)
+   - [Data Collection](#1-data-collection)
+   - [Data Processing](#2-data-processing)
+4. [Model Training](#model-training)
+   - [Machine Learning Framework](#1-machine-learning-framework)
+   - [Model Evaluation](#2-model-evaluation)
+5. [Model Packaging with BentoML](#model-packaging-with-bentoml)
+6. [Configuring BentoML for Data Serialization](#configuring-bentoml-for-data-serialization)
+7. [Model Serving](#model-serving)
+8. [Model Testing](#model-testing)
+9. [Documentation and Presentation](#documentation-and-presentation)
+10. [Suggested Tech Stack](#suggested-tech-stack)
+11. [Repository Structure](#repository-structure)
+12. [Open Issues and Milestones](#open-issues-and-milestones)
+13. [Presentations](#presentations)
+14. [Future Work](#future-work)
+
+
 # MLOps for Document Classification Models
 
 This project demonstrates a workflow for creating, training, packaging, and serving a document classification model, focusing on the 20 Newsgroups dataset. It incorporates machine learning and natural language processing techniques.


### PR DESCRIPTION
This update is part of our ongoing efforts to improve project documentation as outlined in **Issue 6**.

The Table of Contents (TOC) includes links to all major sections and subsections of the document. The purpose of it is to enhance the readability and navigability of the README file and to allow quick access to specific sections, especially beneficial for external contributors. I used Markdown formatting for creating hyperlinked TOC items. The TOC follows GitHub's Markdown style, ensuring it renders correctly in the repository view.

Please review the structure and links in the TOC to ensure they correctly correspond to the README sections. Feedback on the comprehensiveness and clarity of the TOC is also welcome.

